### PR TITLE
Added Suzuki SUZ18 key type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.5 
+* Added Suzuki SUZ18 key format support by @RIcePatrol
+
 ## 1.4
 * Added Weiser WR3 key format support by @lightos
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To measure your key:
 - Thank [@HonestLocksmith](https://github.com/HonestLocksmith) for PR #13 and #20. TONS of new key formats and supports for DOUBLE-SIDED keys are added. We have car keys now!
 - Thank [@Offreds](https://github.com/Offreds) for PR #32. We now have a more streamlined workflow for key format selection. 
 - Thank [@lightos](https://github.com/lightos) for PR #36. Weiser WR3 key format was added.
+- Thank [@RIcePatrol](https://github.com/RIcePatrol) for PR #37. Suzuki SUZ18 key format was added.
 - Hey! We are on [Adam Savage's show](https://youtu.be/c8q2YVRiOAE?t=485)! Thanks for featuring my app! 
 - We also made it to @TalkingSasquach's YouTube! He's made an awesome walkthrough from decoding the key bitting to 3D-printing copies. [Check it out!](https://www.youtube.com/watch?v=P3-KhSJE1as)
 

--- a/application.fam
+++ b/application.fam
@@ -12,6 +12,6 @@ App(
     fap_category="Tools",
     fap_icon_assets="assets",
     fap_description="@README.md",
-    fap_version="1.4",
+    fap_version="1.5",
     fap_author="Torron"
 )

--- a/key_copier.c
+++ b/key_copier.c
@@ -642,7 +642,7 @@ static KeyCopierApp* key_copier_app_alloc() {
     app->dialogs = furi_record_open(RECORD_DIALOGS);
     app->file_path = furi_string_alloc();
     app->submenu = submenu_alloc();
-    submenu_set_header(app->submenu, "Key Copier v1.4");
+    submenu_set_header(app->submenu, "Key Copier v1.5");
     submenu_add_item(
         app->submenu,
         "Select Key Format",
@@ -716,7 +716,7 @@ static KeyCopierApp* key_copier_app_alloc() {
         0,
         128,
         64,
-        "Key Maker App 1.4\nAuthor: @Torron\n\nTo measure your key:\n\n1. Place "
+        "Key Maker App 1.5\nAuthor: @Torron\n\nTo measure your key:\n\n1. Place "
         "it on top of the screen.\n\n2. Use the contour to align your key.\n\n3. "
         "Adjust each pin's depth until they match. It's easier if you look with "
         "one eye closed.\n\nGithub: github.com/zinongli/KeyCopier \n\nSpecial "

--- a/key_formats.c
+++ b/key_formats.c
@@ -356,6 +356,26 @@ const KeyFormat all_formats[] = {
      .macs = 4,
      .clearance = 3},
 
+    {.manufacturer = "Suzuki",
+     .format_name = "SUZ18",
+     .sides = 2,
+     .format_link = "X241",
+     .first_pin_inch = 0.16,
+     .last_pin_inch = 0.73,
+     .pin_increment_inch = 0.095,
+     .pin_num = 7,
+     .pin_width_inch = 0.045,
+     .elbow_inch = 0.1, // this should be equal to first pin inch for tip
+     // stopped key line
+     .drill_angle = 90,
+     .uncut_depth_inch = 0.28,
+     .deepest_depth_inch = 0.22,
+     .depth_step_inch = 0.020,
+     .min_depth_ind = 1,
+     .max_depth_ind = 4,
+     .macs = 4,
+     .clearance = 4},
+
     {.manufacturer = "Yamaha",
      .format_name = "YM63",
      .sides = 2,

--- a/key_formats.c
+++ b/key_formats.c
@@ -374,7 +374,7 @@ const KeyFormat all_formats[] = {
      .min_depth_ind = 1,
      .max_depth_ind = 4,
      .macs = 4,
-     .clearance = 4},
+     .clearance = 3},
 
     {.manufacturer = "Yamaha",
      .format_name = "YM63",

--- a/key_formats.h
+++ b/key_formats.h
@@ -1,7 +1,7 @@
 #ifndef KEY_FORMATS_H
 #define KEY_FORMATS_H
 
-#define FORMAT_NUM 22
+#define FORMAT_NUM 23
 
 typedef struct {
     char* manufacturer;


### PR DESCRIPTION
The Suzuki SUZ18 key is used on the 1998-2006 Katana among other models. Measured and verified it matches two keys from two different year bikes I have on hand.